### PR TITLE
fix: add missing id and icon for 'commands' level in dojo.yml

### DIFF
--- a/dojo.yml
+++ b/dojo.yml
@@ -13,3 +13,6 @@ modules:
     
   - id: "paths"
     icon: 0023_Ekans
+
+  - id: "commands"
+    icon: 0875_Eiscue


### PR DESCRIPTION
dojo.yml中没有配置commands关卡的id和图标，导致道馆中不显示这一关。
本次提交补全相关字段，使关卡正常显示。