### PR TITLE
新增man模块下关卡

### DIFF
--- a/man/builtins/bashansi.h
+++ b/man/builtins/bashansi.h
@@ -1,0 +1,14 @@
+#ifndef _BASHANSI_H_
+#define _BASHANSI_H_
+
+#if defined (__STDC__)
+#  define PROTOTYPES 1
+#endif
+
+#if defined (PROTOTYPES)
+#  define P(args) args
+#else
+#  define P(args) ()
+#endif
+
+#endif /* _BASHANSI_H_ */

--- a/man/builtins/builtins.h
+++ b/man/builtins/builtins.h
@@ -1,0 +1,16 @@
+#ifndef _BUILTINS_H_
+#define _BUILTINS_H_
+
+#include "shell.h"
+
+/* 描述一个 Shell 内建命令的结构体 */
+typedef struct builtin {
+  char *name;           /* 内建命令的名称 */
+  int (*function)();    /* 实现该命令的函数指针 */
+  int flags;            /* 标志位, 如 BUILTIN_ENABLED */
+  char **long_doc;      /* 详细的帮助文档 */
+  char *short_doc;      /* 简短的用法摘要 */
+  char *handle;         /* 内部使用 */
+} BUILTIN;
+
+#endif /* _BUILTINS_H_ */

--- a/man/builtins/challenge.c
+++ b/man/builtins/challenge.c
@@ -1,6 +1,6 @@
 #include "loadables.h"
 #include "bashansi.h"
-#include <config.h>
+#include "config.h"
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/man/builtins/config.h
+++ b/man/builtins/config.h
@@ -1,0 +1,6 @@
+#ifndef _CONFIG_H_
+#define _CONFIG_H_
+
+#define BUILTIN_ENABLED 0x1
+
+#endif /* _CONFIG_H_ */

--- a/man/builtins/loadables.h
+++ b/man/builtins/loadables.h
@@ -1,0 +1,10 @@
+#ifndef _LOADABLES_H_
+#define _LOADABLES_H_
+
+#include "config.h"
+#include "builtins.h"
+
+int challenge_builtin_load(char *);
+void challenge_builtin_unload(char *);
+
+#endif /* _LOADABLES_H_ */

--- a/man/builtins/shell.h
+++ b/man/builtins/shell.h
@@ -1,0 +1,22 @@
+#ifndef _SHELL_H_
+#define _SHELL_H_
+
+#include "variables.h"
+
+/* WORD_LIST 的 `word` 部分 */
+typedef struct word_desc {
+  char *word;
+  int flags;
+} WORD_DESC;
+
+/* 单词列表结构体 */
+typedef struct word_list {
+  struct word_list *next;
+  WORD_DESC *word;
+} WORD_LIST;
+
+/* 执行返回值宏 */
+#define EXECUTION_SUCCESS 0
+#define EXECUTION_FAILURE 1
+
+#endif /* _SHELL_H_ */

--- a/man/builtins/variables.h
+++ b/man/builtins/variables.h
@@ -1,0 +1,16 @@
+#ifndef _VARIABLES_H_
+#define _VARIABLES_H_
+
+/* Shell 变量的结构体 */
+typedef struct shell_var {
+  char *name;
+  char *value;
+  int attributes;
+  struct shell_var *next;
+} SHELL_VAR;
+
+SHELL_VAR *find_variable(char*);
+char *get_variable_value(SHELL_VAR*);
+//int bind_global_variable(char*, char*, int); 
+
+#endif /* _VARIABLES_H_ */

--- a/man/module.yml
+++ b/man/module.yml
@@ -20,9 +20,8 @@ challenges:
   - id: "help"
     name: 有用的程序
   
-  #缺少必要依赖库
-  #- id: "builtins"
-    #name: 获取内建命令的帮助
+  - id: "builtins"
+    name: 获取内建命令的帮助
 
 resources:
 - name: Resources


### PR DESCRIPTION
将原本隐藏的关卡重新显示出来。因为只有当dojo_challenge设置为full时才会执行builder-tools-apt-yes下的软件包的安装，而我本地部署的dojo_challenge设置为mini，没办法直接测试添加的库是否有效。所以使用替代方案，直接将C文件所缺少的头文件手动添加到同一个目录中。在本地测试后关卡能够正常运行并通关。